### PR TITLE
Clarify timezone env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DISCORD_TOKEN=your_discord_bot_token_here
 CHANNEL_ID=your_channel_id_here      # channel where reminders go
 ROLE_ID=your_role_id_here            # Editor role ID (without <@& >)
-TZ=Europe/Berlin                     # IANA timezone
+TIMEZONE=Europe/Berlin                     # IANA timezone
 
 # Notion Integration
 NOTION_TOKEN=secret_xxx              # Notion API integration token

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,7 +18,7 @@ Before deploying, make sure you have:
    - `DISCORD_TOKEN`
    - `CHANNEL_ID`
    - `ROLE_ID`
-   - `TZ`
+   - `TIMEZONE`
 5. Deploy the project
 
 ## Option 2: Deploy on Repl.it
@@ -29,7 +29,7 @@ Before deploying, make sure you have:
    - `DISCORD_TOKEN`
    - `CHANNEL_ID`
    - `ROLE_ID`
-   - `TZ`
+   - `TIMEZONE`
 4. Use the "Run" button to start your bot
 5. Set up Repl.it's "Always On" feature to keep your bot running
 
@@ -44,7 +44,7 @@ Before deploying, make sure you have:
    - `DISCORD_TOKEN`
    - `CHANNEL_ID`
    - `ROLE_ID`
-   - `TZ`
+   - `TIMEZONE`
 7. Deploy the service
 
 ## Option 4: Deploy on Fly.io
@@ -57,7 +57,7 @@ Before deploying, make sure you have:
    fly secrets set DISCORD_TOKEN=your_token_here
    fly secrets set CHANNEL_ID=your_channel_id
    fly secrets set ROLE_ID=your_role_id
-   fly secrets set TZ=Europe/Berlin
+   fly secrets set TIMEZONE=Europe/Berlin
    ```
 5. Deploy: `fly deploy`
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ NOTION_TOKEN=your_notion_integration_token
 NOTION_DB_ID=your_notion_database_id
 NOTION_WORKSPACE=your_notion_workspace_name (optional, for correct URL linking)
 OPENAI_API_KEY=your_openai_api_key
-TZ=your_timezone (e.g., Europe/Berlin)
+TIMEZONE=your_timezone (e.g., Europe/Berlin)
 ```
+
+The bot primarily uses the `TIMEZONE` variable for scheduling. If your
+deployment platform relies on the standard `TZ` variable, you can set both to
+the same value.
 
 ## Deployment
 

--- a/SETUP_RAILWAY.md
+++ b/SETUP_RAILWAY.md
@@ -12,7 +12,7 @@ To properly deploy your Discord bot to Railway and fix the Notion URL linking is
 | `NOTION_TOKEN` | Your Notion integration token | `secret_abcdefg123456789` |
 | `NOTION_DB_ID` | Your Notion database ID | `abcdefg123456789` |
 | `OPENAI_API_KEY` | Your OpenAI API key for AI functions | `sk-abcdefg123456789` |
-| `TZ` | Your timezone for scheduling | `Europe/Berlin` |
+| `TIMEZONE` | Your timezone for scheduling | `Europe/Berlin` |
 | `NOTION_WORKSPACE` | Your Notion workspace name (for correct URL linking) | `your-workspace` |
 
 ## How to Find Your Notion Workspace Name

--- a/start.js
+++ b/start.js
@@ -22,7 +22,7 @@ console.log(`- .env file ${result.error ? 'not loaded (using system env)' : 'loa
 console.log(`- DISCORD_TOKEN: ${process.env.DISCORD_TOKEN ? 'Set ✓' : 'Not set ✗'}`);
 console.log(`- CHANNEL_ID: ${process.env.CHANNEL_ID || 'Not set ✗'}`);
 console.log(`- ROLE_ID: ${process.env.ROLE_ID || 'Not set ✗'}`);
-console.log(`- TZ: ${process.env.TZ || 'Not set (using Europe/Berlin)'}`);
+console.log(`- TIMEZONE: ${process.env.TIMEZONE || process.env.TZ || 'Europe/Berlin'}`);
 console.log('\nStarting bot (press Ctrl+C to stop)...\n');
 
 // Start the bot


### PR DESCRIPTION
## Summary
- document TIMEZONE environment variable in README
- update example env files and deployment docs
- show TIMEZONE value on startup

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*