### PR TITLE
Remove placeholders from writer setup guide

### DIFF
--- a/guides/text/6ada6e0e-5357-48ac-a99f-06013e8ab1c6_Writer_setup_guide.txt
+++ b/guides/text/6ada6e0e-5357-48ac-a99f-06013e8ab1c6_Writer_setup_guide.txt
@@ -18,8 +18,3 @@ similar to viruses, such as altering system files.
  So to do this go to your windows defender settings - virus & threat protection - 
 manage settings - turn off real time protection. You can turn it on again once 
 the installation is done.
-Writer setup guide1
-
-Writer setup guide2
-
-Writer setup guide3


### PR DESCRIPTION
## Summary
- clean up extraneous placeholder text at the end of the Writer setup guide

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*