### PR TITLE
Add file-based issue reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The bot supports various slash commands:
 - `/schedule` - View the reminder schedule
 - `/notion` - Manage Notion status watchers
 - `/set` - Update properties on a Notion page
+- `/issue-report <timeframe>` - Compile recent Discord messages and Frame.io comments into text files
 
 ## Custom Watchers
 

--- a/commands.js
+++ b/commands.js
@@ -220,6 +220,14 @@ const commands = {
     
     // Add check-tasks command to manually run the end-of-day task check
     new SlashCommandBuilder().setName('check-tasks').setDescription('Check for completed tasks in recent messages'),
+
+    // Add issue-report command to compile logs from Discord and Frame.io
+    new SlashCommandBuilder().setName('issue-report').setDescription('Compile a report of recent messages')
+      .addStringOption(option =>
+        option.setName('timeframe').setDescription('Timeframe to analyze')
+          .setRequired(true)
+          .addChoices({ name: 'Week', value: 'week' }, { name: 'Month', value: 'month' }))
+      .addBooleanOption(option => option.setName('ephemeral').setDescription('Make the response only visible to you')),
   ],
 };
 


### PR DESCRIPTION
## Summary
- expand `/issue-report` command: gather a month of messages and Frame.io comments
- save Discord and Frame.io logs as text files
- adjust documentation for the new behaviour

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*