### PR TITLE
Document Frame.io env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
 TIMEZONE=your_timezone (e.g., Europe/Berlin)
 ```
 
+For Frame.io integration, provide:
+
+- `FRAMEIO_TOKEN` – your Frame.io API token
+- `FRAMEIO_ACCOUNT_ID` – your Frame.io account ID (auto-detected if omitted)
+
 The bot primarily uses the `TIMEZONE` variable for scheduling. If your
 deployment platform relies on the standard `TZ` variable, you can set both to
 the same value.

--- a/config.example.env
+++ b/config.example.env
@@ -9,6 +9,10 @@ NOTION_CHANGELOG_DB_ID=your_notion_changelog_db_id_here
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Frame.io Integration
+#FRAMEIO_TOKEN=your_frameio_api_token_here
+#FRAMEIO_ACCOUNT_ID=your_frameio_account_id_here
+
 # Timezone Setting
 TIMEZONE=Europe/Berlin
 


### PR DESCRIPTION
## Summary
- list FRAMEIO_TOKEN and FRAMEIO_ACCOUNT_ID variables in README
- show Frame.io placeholders in config.example.env

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*