### PR TITLE
Add Frame.io test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ NOTION_WORKSPACE=your_notion_workspace_name (optional, for correct URL linking)
 OPENAI_API_KEY=your_openai_api_key
 FRAMEIO_TOKEN=your_frameio_api_token (optional)
 FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
+FRAMEIO_ROOT_ASSET_ID=your_frameio_project_root_id (optional)
 TIMEZONE=your_timezone (e.g., Europe/Berlin)
 ```
 
@@ -32,6 +33,7 @@ For Frame.io integration, provide:
 
 - `FRAMEIO_TOKEN` – your Frame.io API token
 - `FRAMEIO_ACCOUNT_ID` – your Frame.io account ID (auto-detected if omitted)
+- `FRAMEIO_ROOT_ASSET_ID` – root asset ID of the project for comment scraping
 
 The bot primarily uses the `TIMEZONE` variable for scheduling. If your
 deployment platform relies on the standard `TZ` variable, you can set both to
@@ -71,6 +73,7 @@ The bot supports various slash commands:
 - `/notion` - Manage Notion status watchers
 - `/set` - Update properties on a Notion page
 - `/issue-report <timeframe>` - Compile recent Discord messages, Frame.io comments, Notion changelog entries and project assignments into text files
+- `/frameio [timeframe]` - Fetch recent Frame.io comments to test connectivity
 
 ## Creds 2.0
 

--- a/commands.js
+++ b/commands.js
@@ -228,6 +228,13 @@ const commands = {
           .setRequired(true)
           .addChoices({ name: 'Week', value: 'week' }, { name: 'Month', value: 'month' }))
       .addBooleanOption(option => option.setName('ephemeral').setDescription('Make the response only visible to you')),
+
+    // Simple command to test Frame.io connectivity
+    new SlashCommandBuilder().setName('frameio').setDescription('Fetch recent Frame.io comments')
+      .addStringOption(option =>
+        option.setName('timeframe').setDescription('Timeframe to fetch')
+          .addChoices({ name: 'Week', value: 'week' }, { name: 'Month', value: 'month' }))
+      .addBooleanOption(option => option.setName('ephemeral').setDescription('Make the response only visible to you')),
   ],
 
   // Economy commands

--- a/config.example.env
+++ b/config.example.env
@@ -12,6 +12,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Frame.io Integration
 #FRAMEIO_TOKEN=your_frameio_api_token_here
 #FRAMEIO_ACCOUNT_ID=your_frameio_account_id_here
+#FRAMEIO_ROOT_ASSET_ID=your_project_root_asset_id_here
 
 # Timezone Setting
 TIMEZONE=Europe/Berlin


### PR DESCRIPTION
## Summary
- add `/frameio` command to fetch recent Frame.io comments for testing
- improve error handling in `fetchFrameioComments`
- document the new command in README

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*