### PR TITLE
Fix Frame.io scraping logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ NOTION_WORKSPACE=your_notion_workspace_name (optional, for correct URL linking)
 OPENAI_API_KEY=your_openai_api_key
 FRAMEIO_TOKEN=your_frameio_api_token (optional)
 FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
+FRAMEIO_ROOT_ASSET_ID=your_frameio_project_root_id (optional)
 TIMEZONE=your_timezone (e.g., Europe/Berlin)
 ```
 
@@ -32,6 +33,7 @@ For Frame.io integration, provide:
 
 - `FRAMEIO_TOKEN` – your Frame.io API token
 - `FRAMEIO_ACCOUNT_ID` – your Frame.io account ID (auto-detected if omitted)
+- `FRAMEIO_ROOT_ASSET_ID` – root asset ID of the project for comment scraping
 
 The bot primarily uses the `TIMEZONE` variable for scheduling. If your
 deployment platform relies on the standard `TZ` variable, you can set both to

--- a/config.example.env
+++ b/config.example.env
@@ -12,6 +12,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Frame.io Integration
 #FRAMEIO_TOKEN=your_frameio_api_token_here
 #FRAMEIO_ACCOUNT_ID=your_frameio_account_id_here
+#FRAMEIO_ROOT_ASSET_ID=your_project_root_asset_id_here
 
 # Timezone Setting
 TIMEZONE=Europe/Berlin

--- a/index.js
+++ b/index.js
@@ -5662,9 +5662,48 @@ async function resolveFrameioAccountId() {
   return null;
 }
 
+// Recursively collect comments from a Frame.io project
+async function collectFrameioComments(assetId, since, headers, comments) {
+  const resp = await axios.get(`https://api.frame.io/v2/assets/${assetId}/children`, { headers });
+  for (const asset of resp.data) {
+    if (asset.type === 'file') {
+      if (asset.comment_count > 0) {
+        const cr = await axios.get(`https://api.frame.io/v2/assets/${asset.id}/comments`, { headers });
+        for (const c of cr.data) {
+          if (new Date(c.created_at).getTime() >= since) {
+            comments.push(`[${asset.name}] ${c.text}`);
+            if (comments.length >= 1000) return;
+          }
+        }
+      }
+    } else if (asset.type === 'folder' || asset.type === 'version_stack') {
+      await collectFrameioComments(asset.id, since, headers, comments);
+      if (comments.length >= 1000) return;
+    }
+  }
+}
+
 // Fetch comments from Frame.io if credentials are provided
 async function fetchFrameioComments(timeframe) {
   if (!process.env.FRAMEIO_TOKEN) return [];
+  const days = timeframe === 'month' ? 30 : 7;
+  const since = Date.now() - days * 24 * 60 * 60 * 1000;
+  const headers = { Authorization: `Bearer ${process.env.FRAMEIO_TOKEN}` };
+
+  // Prefer crawling a specific project if a root asset ID is provided
+  const rootAsset = process.env.FRAMEIO_ROOT_ASSET_ID;
+  if (rootAsset) {
+    try {
+      const comments = [];
+      await collectFrameioComments(rootAsset, since, headers, comments);
+      return comments;
+    } catch (err) {
+      logToFile(`Error fetching Frame.io comments: ${err.message}`);
+      return [];
+    }
+  }
+
+  // Fallback to account-wide comments using the account ID
   let accountId = process.env.FRAMEIO_ACCOUNT_ID;
   if (!accountId) {
     accountId = await resolveFrameioAccountId();
@@ -5673,9 +5712,6 @@ async function fetchFrameioComments(timeframe) {
       return [];
     }
   }
-  const days = timeframe === 'month' ? 30 : 7;
-  const since = Date.now() - days * 24 * 60 * 60 * 1000;
-  const headers = { Authorization: `Bearer ${process.env.FRAMEIO_TOKEN}` };
   try {
     const url = `https://api.frame.io/v2/accounts/${accountId}/comments`;
     const resp = await axios.get(url, { headers });


### PR DESCRIPTION
## Summary
- fix truncated index.js causing syntax error
- include Frame.io project root scraping logic

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*