### PR TITLE
Add email forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A powerful Discord bot that integrates with Notion to manage projects, schedule 
 - **Meeting Coordination**: Schedule and coordinate meetings with team members
 - **Customizable Watchers**: Get notified when Notion properties change
 - **Creds 2.0 Economy**: Earn and spend Creds through `/kudos`, check balances with `/creds`, and redeem rewards from `/shop`.
+- **Email Forwarding**: Send emails arriving at `dropbox@matcher.com` straight to your Discord channel.
 
 ## Environment Variables
 
@@ -29,6 +30,7 @@ FRAMEIO_TOKEN=your_frameio_api_token (optional)
 FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
 
 TIMEZONE=your_timezone (e.g., Europe/Berlin)
+EMAIL_CHANNEL_ID=channel_id_for_forwarding
 ```
 
 For Frame.io integration, provide:
@@ -78,6 +80,13 @@ the same value.
 2. Install dependencies: `npm install`
 3. Create a `.env` file with the required environment variables
 4. Run the bot: `node index.js`
+
+## Email Forwarding
+
+1. Configure your email provider (e.g., SendGrid or Mailgun) to POST incoming
+   messages to `/incoming-email` on your deployed bot.
+2. Set `EMAIL_CHANNEL_ID` in your `.env` with the Discord channel that should
+   receive the messages.
 
 ### Using GitHub Actions + Railway
 

--- a/config.example.env
+++ b/config.example.env
@@ -27,6 +27,7 @@ SCHEDULE_CHANNEL_ID=your_schedule_channel_id_here
 MESSAGE_BACKUP_CHANNEL_ID=your_message_backup_channel_id_here
 TODO_CHANNEL_ID=your_todo_channel_id_here
 TEAM_ROLE_ID=your_team_role_id_here
+EMAIL_CHANNEL_ID=your_email_forward_channel_id
 
 # Guild (Server) ID
 GUILD_ID=your_guild_id_here 

--- a/email_forwarder.js
+++ b/email_forwarder.js
@@ -1,0 +1,41 @@
+// email_forwarder.js - handle incoming email webhooks and forward to Discord
+
+const express = require('express');
+const { logToFile } = require('./log_utils');
+
+/**
+ * Initialize email forwarding endpoint
+ * @param {express.Express} app - Express app to attach the route to
+ * @param {import('discord.js').Client} client - Discord client used to send messages
+ * @param {string} channelId - ID of the Discord channel to forward emails to
+ */
+function initEmailForwarder(app, client, channelId) {
+  if (!app || !client || !channelId) {
+    logToFile('Email forwarder not initialized - missing parameters');
+    return;
+  }
+
+  app.use(express.json({ limit: '10mb' }));
+
+  app.post('/incoming-email', async (req, res) => {
+    const { from, subject, text } = req.body;
+    if (!from || !subject || !text) {
+      res.status(400).send('Missing required fields');
+      return;
+    }
+
+    try {
+      const channel = await client.channels.fetch(channelId);
+      const message = `**Email from ${from}**\n**Subject:** ${subject}\n\n${text}`;
+      await channel.send(message);
+      res.status(200).send('ok');
+    } catch (error) {
+      logToFile(`Error forwarding email: ${error.message}`);
+      res.status(500).send('error');
+    }
+  });
+
+  logToFile('Email forwarder initialized');
+}
+
+module.exports = { initEmailForwarder };

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const express = require('express');
 const cors = require('cors');
 const app = express();
 const { commands } = require('./commands');
+const { initEmailForwarder } = require('./email_forwarder');
 
 // Simple helper for rate-limited GET requests with retries
 async function axiosGetWithRetry(url, headers, retries = 3, backoff = 1000) {
@@ -83,6 +84,8 @@ const MESSAGE_BACKUP_CHANNEL_ID = '1296549507357741086'; // Channel to backup me
 const TEAM_ROLE_ID = '1364657163598823474';
 // To-do list channel ID
 const TODO_CHANNEL_ID = process.env.TODO_CHANNEL_ID;
+// Email forwarding channel ID
+const EMAIL_CHANNEL_ID = process.env.EMAIL_CHANNEL_ID;
 
 // Store jobs in memory, each with a tag, cron expression, text, and whether to send a notification 5 min before
 let jobs = [
@@ -6433,3 +6436,13 @@ function loadRecentMessages() {
 
 // Expose the recent messages array globally for the knowledge assistant
 global.recentMessages = recentMessages;
+
+// Start email forwarding server if channel ID is provided
+if (EMAIL_CHANNEL_ID) {
+  initEmailForwarder(app, client, EMAIL_CHANNEL_ID);
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Email forwarder listening on port ${PORT}`);
+    logToFile(`Email forwarder listening on port ${PORT}`);
+  });
+}


### PR DESCRIPTION
## Summary
- forward incoming mail to a Discord channel via `/incoming-email` webhook
- document the email forwarding environment variable and setup

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*