### PR TITLE
Fix /create orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ The bot supports various slash commands:
 - `/frameio [timeframe]` - Fetch recent Frame.io comments to test connectivity
 - `/vo <text>` - Generate an ElevenLabs voiceover and send it
 - `/video <prompt> <image>` - Generate a video from an image using Runway
-- `/create <prompt>` - Generate a RED-MONOLITH style image using GPT
+ - `/create <prompt>` - Generate a RED-MONOLITH style image using GPT
+   (images are generated at 1792x1024 resolution to approximate a 16:9 canvas)
 
 ## Creds 2.0
 

--- a/index.js
+++ b/index.js
@@ -4195,7 +4195,9 @@ Example Output: {
           model: 'dall-e-3',
           prompt: stylePrompt,
           n: 1,
-          size: '1024x576'
+          // Use the widest orientation supported by the API to approximate 16:9
+          // (1792x1024 is very close to 1.77 : 1)
+          size: '1792x1024'
         });
 
         const imageUrl = response.data[0]?.url;


### PR DESCRIPTION
## Summary
- fix the image size for the `/create` command to use DALL·E 3 supported 1792x1024
- document the new resolution in the README

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*