### PR TITLE
Add RUNWAY_MODEL env variable for /video command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ OPENAI_API_KEY=your_openai_api_key
 ELEVENLABS_API_KEY=your_elevenlabs_api_key
 ELEVENLABS_VOICE_ID=your_elevenlabs_voice_id
 RUNWAY_API_KEY=your_runway_api_key
+RUNWAY_MODEL=stable-video-diffusion
 FRAMEIO_TOKEN=your_frameio_api_token (optional)
 FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
 

--- a/config.example.env
+++ b/config.example.env
@@ -15,6 +15,7 @@ ELEVENLABS_VOICE_ID=your_elevenlabs_voice_id_here
 
 # Runway Video Generation
 RUNWAY_API_KEY=your_runway_api_key_here
+RUNWAY_MODEL=stable-video-diffusion
 
 # Frame.io Integration
 #FRAMEIO_TOKEN=your_frameio_api_token_here

--- a/index.js
+++ b/index.js
@@ -492,6 +492,7 @@ const NOTION_TASKS_URL = process.env.NOTION_TASKS_URL ||
   (DB ? `https://www.notion.so/${NOTION_WORKSPACE ? `${NOTION_WORKSPACE}/` : ''}${DB.replace(/-/g, '')}` : null);
 const CHANGELOG_DB = process.env.NOTION_CHANGELOG_DB_ID; // No hardcoded fallback - rely on environment variable
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const RUNWAY_MODEL = process.env.RUNWAY_MODEL;
 const GUILD_ID = process.env.GUILD_ID;
 
 // Status watchers configuration
@@ -512,6 +513,7 @@ console.log(`- NOTION_DATABASE_ID: ${DB ? `✅ Set (${DB.substring(0, 6)}...)` :
 console.log(`- NOTION_CHANGELOG_DB_ID: ${CHANGELOG_DB ? `✅ Set (${CHANGELOG_DB.substring(0, 6)}...)` : '❌ Missing'}`);
 console.log(`- NOTION_TASKS_URL: ${NOTION_TASKS_URL ? '✅ Set' : '❌ Missing (will use default)'}`);
 console.log(`- OPENAI_API_KEY: ${OPENAI_API_KEY ? '✅ Set' : '❌ Missing'}`);
+console.log(`- RUNWAY_MODEL: ${RUNWAY_MODEL ? '✅ Set' : '❌ Missing'}`);
 
 // Validate required environment variables
 if (!TOKEN) {
@@ -4123,9 +4125,14 @@ Example Output: {
         const prompt = interaction.options.getString('prompt');
         const image = interaction.options.getAttachment('image');
         const apiKey = process.env.RUNWAY_API_KEY;
+        const model = RUNWAY_MODEL;
 
         if (!apiKey) {
           await interaction.editReply('❌ Runway API not configured.');
+          return;
+        }
+        if (!model) {
+          await interaction.editReply('❌ Runway model not configured.');
           return;
         }
         if (!image) {
@@ -4136,6 +4143,7 @@ Example Output: {
         const startResp = await axios.post(
           'https://api.runwayml.com/v1/inferences',
           {
+            model,
             input: { prompt, image: image.url }
           },
           { headers: { Authorization: `Bearer ${apiKey}` } }


### PR DESCRIPTION
## Summary
- expose a `RUNWAY_MODEL` setting in `config.example.env` and README
- include `RUNWAY_MODEL` in startup logs
- require model in `/video` command and send it to Runway API

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*
- `npm run check-env` *(fails: Cannot find module 'dotenv')*