### PR TITLE
Add incoming-email slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The bot supports various slash commands:
 - `/vo <text>` - Generate an ElevenLabs voiceover and send it
 - `/video <prompt> <image>` - Generate a video from an image using Runway
 - `/create <prompt>` - Generate a RED-MONOLITH style image using GPT
+- `/incoming-email` - Display instructions for forwarding emails to Discord
 
 ## Creds 2.0
 

--- a/commands.js
+++ b/commands.js
@@ -251,6 +251,10 @@ const commands = {
       // Generate an image using the GPT image API
       new SlashCommandBuilder().setName('create').setDescription('Create an image with the RED-MONOLITH style')
         .addStringOption(option => option.setName('prompt').setDescription('Prompt for the image').setRequired(true)),
+
+      // Provide instructions for forwarding emails to Discord
+      new SlashCommandBuilder().setName('incoming-email').setDescription('Show the webhook endpoint for email forwarding')
+        .addBooleanOption(option => option.setName('ephemeral').setDescription('Show the response only to you')),
     ],
 
   // Economy commands

--- a/index.js
+++ b/index.js
@@ -4326,6 +4326,15 @@ Example Output: {
         await interaction.reply({ content: `You redeemed **${reward.name}** for ${reward.cost} Creds!`, ephemeral: true });
       }
     }
+
+    // Handle the /incoming-email command
+    else if (commandName === 'incoming-email') {
+      const ephemeral = interaction.options.getBoolean('ephemeral') ?? true;
+      const instructions = EMAIL_CHANNEL_ID
+        ? `Configure your email provider to POST to \`/incoming-email\`. Emails will be forwarded to <#${EMAIL_CHANNEL_ID}>.`
+        : 'Email forwarding is not configured. Set EMAIL_CHANNEL_ID in the environment variables.';
+      await interaction.reply({ content: instructions, ephemeral });
+    }
     
     // Other commands here
     // ...


### PR DESCRIPTION
## Summary
- add `/incoming-email` command definition
- implement `/incoming-email` handler
- document the new command in README

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*