### PR TITLE
Add duration option to video command

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The bot supports various slash commands:
 - `/issue-report <timeframe>` - Compile recent Discord messages, Frame.io comments, Notion changelog entries and project assignments into text files
 - `/frameio [timeframe]` - Fetch recent Frame.io comments to test connectivity
 - `/vo <text>` - Generate an ElevenLabs voiceover and send it
-- `/video <prompt> <image>` - Generate a video from an image using Runway
+- `/video <prompt> <image> [duration]` - Generate a video from an image using Runway
 
 
 ## Creds 2.0

--- a/commands.js
+++ b/commands.js
@@ -246,7 +246,8 @@ const commands = {
       // Generate a short video using Runway
       new SlashCommandBuilder().setName('video').setDescription('Create a video with Runway from an image and prompt')
         .addAttachmentOption(option => option.setName('image').setDescription('Input image').setRequired(true))
-        .addStringOption(option => option.setName('prompt').setDescription('Prompt for the video').setRequired(true)),
+        .addStringOption(option => option.setName('prompt').setDescription('Prompt for the video').setRequired(true))
+        .addIntegerOption(option => option.setName('duration').setDescription('Duration in seconds (default: 5)')),
 
       // Generate an image using the GPT image API
       new SlashCommandBuilder().setName('create').setDescription('Create an image with the RED-MONOLITH style')

--- a/index.js
+++ b/index.js
@@ -4124,6 +4124,7 @@ Example Output: {
 
         const prompt = interaction.options.getString('prompt');
         const image = interaction.options.getAttachment('image');
+        const duration = interaction.options.getInteger('duration') || 5;
         const apiKey = process.env.RUNWAY_API_KEY;
         const model = RUNWAY_MODEL;
 
@@ -4144,7 +4145,7 @@ Example Output: {
           'https://api.runwayml.com/v1/inferences',
           {
             model,
-            input: { prompt, image: image.url }
+            input: { prompt, image: image.url, duration }
           },
           { headers: { Authorization: `Bearer ${apiKey}` } }
         );


### PR DESCRIPTION
## Summary
- allow `/video` to specify a duration parameter
- include duration in API call
- document the new parameter

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*