### PR TITLE
Improve error logging for /video

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { Client: NotionClient } = require('@notionhq/client');
 const cron = require('node-cron');
 const fs = require('fs'); // Re-add fs module
 const path = require('path');
-const { logToFile, frameioErrorMessage } = require('./log_utils');
+const { logToFile, frameioErrorMessage, axiosErrorMessage } = require('./log_utils');
 const { addCreds } = require('./utils');
 const { loadTasks, saveTasks, addTask } = require('./tasks');
 const points = require('./points');
@@ -4179,11 +4179,12 @@ Example Output: {
         const attachment = new AttachmentBuilder(Buffer.from(videoResp.data), { name: 'video.mp4' });
         await interaction.editReply({ content: '📹 Generated video:', files: [attachment] });
       } catch (error) {
-        logToFile(`Error in /video command: ${error.message}`);
+        const msg = axiosErrorMessage(error, 'Runway video generation');
+        logToFile(`Error in /video command: ${msg}`);
         if (hasResponded) {
-          await interaction.editReply(`❌ ${error.message}`);
+          await interaction.editReply(`❌ ${msg}`);
         } else {
-          await interaction.reply({ content: `❌ ${error.message}`, ephemeral: true });
+          await interaction.reply({ content: `❌ ${msg}`, ephemeral: true });
         }
       }
     }

--- a/log_utils.js
+++ b/log_utils.js
@@ -37,4 +37,22 @@ function frameioErrorMessage(error, action) {
   return `${action} failed: ${error.message}`;
 }
 
-module.exports = { logToFile, frameioErrorMessage };
+/**
+ * Format a generic axios error into a human readable message.
+ * @param {any} error - The error thrown by axios.
+ * @param {string} action - Description of the action being performed.
+ * @returns {string}
+ */
+function axiosErrorMessage(error, action) {
+  if (error.response) {
+    const status = error.response.status;
+    const data =
+      typeof error.response.data === 'object'
+        ? JSON.stringify(error.response.data)
+        : String(error.response.data);
+    return `${action} returned ${status} ${error.response.statusText}: ${data}`;
+  }
+  return `${action} failed: ${error.message}`;
+}
+
+module.exports = { logToFile, frameioErrorMessage, axiosErrorMessage };


### PR DESCRIPTION
## Summary
- add generic axios error formatter
- use it for Runway video generation errors

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*