### PR TITLE
Add Gmail polling to forward emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A powerful Discord bot that integrates with Notion to manage projects, schedule 
 - **Customizable Watchers**: Get notified when Notion properties change
 - **Creds 2.0 Economy**: Earn and spend Creds through `/kudos`, check balances with `/creds`, and redeem rewards from `/shop`.
 - **Email Forwarding**: Send emails arriving at `dropbox@matcher.com` straight to your Discord channel.
+- **Gmail Poller**: Automatically poll Gmail and post new emails to your Discord channel.
 
 ## Environment Variables
 
@@ -33,6 +34,13 @@ FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
 
 TIMEZONE=your_timezone (e.g., Europe/Berlin)
 EMAIL_CHANNEL_ID=channel_id_for_forwarding
+ENABLE_GMAIL_POLLER=false
+GMAIL_CREDENTIALS_PATH=credentials.json
+GMAIL_TOKEN_PATH=token.json
+GMAIL_POLL_INTERVAL=5
+# Optionally provide credentials directly
+GMAIL_CREDENTIALS_JSON=
+GMAIL_TOKEN_JSON=
 ```
 
 For Frame.io integration, provide:
@@ -87,13 +95,15 @@ the same value.
 
 1. Configure your email provider (e.g., SendGrid or Mailgun) to POST incoming
    messages to `/incoming-email` on your deployed bot.
-2. Set `EMAIL_CHANNEL_ID` in your `.env` with the Discord channel that should
-   receive the messages.
+2. Set `EMAIL_CHANNEL_ID` in your `.env` with the Discord channel that should receive the messages.
+
+## Gmail Poller
+Set `ENABLE_GMAIL_POLLER` to `true` to poll Gmail automatically. Provide your Gmail credentials either via `GMAIL_CREDENTIALS_PATH` and `GMAIL_TOKEN_PATH` or by supplying the JSON directly in `GMAIL_CREDENTIALS_JSON` and `GMAIL_TOKEN_JSON`. The bot checks every `GMAIL_POLL_INTERVAL` minutes and posts new emails to `EMAIL_CHANNEL_ID`.
+
 
 ### Using GitHub Actions + Railway
 
 This project is set up to automatically deploy to Railway using GitHub Actions when changes are pushed to the main branch.
-
 To set up continuous deployment:
 
 1. Create a Railway project for your bot

--- a/config.example.env
+++ b/config.example.env
@@ -35,3 +35,12 @@ EMAIL_CHANNEL_ID=your_email_forward_channel_id
 
 # Guild (Server) ID
 GUILD_ID=your_guild_id_here 
+# Gmail Poller
+ENABLE_GMAIL_POLLER=false
+GMAIL_CREDENTIALS_PATH=credentials.json
+GMAIL_TOKEN_PATH=token.json
+GMAIL_POLL_INTERVAL=5
+
+# Optionally provide credentials and token directly as JSON strings
+GMAIL_CREDENTIALS_JSON=
+GMAIL_TOKEN_JSON=

--- a/email_poller.js
+++ b/email_poller.js
@@ -1,0 +1,145 @@
+const { google } = require('googleapis');
+const { authenticate } = require('@google-cloud/local-auth');
+const fs = require('fs').promises;
+const path = require('path');
+const { logToFile } = require('./log_utils');
+
+class GmailPoller {
+  constructor(client, channelId, credsPath, tokenPath, credsJson, tokenJson) {
+    this.client = client;
+    this.channelId = channelId;
+    this.credsPath = credsPath || path.join(process.cwd(), 'credentials.json');
+    this.tokenPath = tokenPath || path.join(process.cwd(), 'token.json');
+    this.credsJson = credsJson || process.env.GMAIL_CREDENTIALS_JSON;
+    this.tokenJson = tokenJson || process.env.GMAIL_TOKEN_JSON;
+    this.gmail = null;
+    this.lastCheckedHistoryId = null;
+  }
+
+  async initialize() {
+    try {
+      const auth = await this.authenticate();
+      this.gmail = google.gmail({ version: 'v1', auth });
+      const profile = await this.gmail.users.getProfile({ userId: 'me' });
+      this.lastCheckedHistoryId = profile.data.historyId;
+      logToFile('Gmail polling initialized');
+    } catch (error) {
+      logToFile(`Error initializing Gmail poller: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async authenticate() {
+    const SCOPES = ['https://www.googleapis.com/auth/gmail.readonly'];
+    let credentials;
+    if (this.credsJson) {
+      credentials = JSON.parse(this.credsJson);
+    } else {
+      credentials = JSON.parse(await fs.readFile(this.credsPath, 'utf8'));
+    }
+
+    const { client_secret, client_id, redirect_uris } = credentials.installed || credentials.web;
+    const oAuth2Client = new google.auth.OAuth2(client_id, client_secret, redirect_uris[0]);
+
+    if (this.tokenJson) {
+      oAuth2Client.setCredentials(JSON.parse(this.tokenJson));
+      return oAuth2Client;
+    }
+
+    try {
+      const token = await fs.readFile(this.tokenPath, 'utf8');
+      oAuth2Client.setCredentials(JSON.parse(token));
+      return oAuth2Client;
+    } catch (err) {
+      const auth = await authenticate({ scopes: SCOPES, keyfilePath: this.credsPath });
+      if (this.tokenPath) {
+        await fs.writeFile(this.tokenPath, JSON.stringify(auth.credentials));
+      }
+      return auth;
+    }
+  }
+
+  async checkForNewEmails() {
+    try {
+      const history = await this.gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: this.lastCheckedHistoryId,
+      });
+      if (!history.data.history) {
+        return;
+      }
+      const messageIds = new Set();
+      for (const item of history.data.history) {
+        if (item.messagesAdded) {
+          item.messagesAdded.forEach(m => messageIds.add(m.message.id));
+        }
+      }
+      for (const id of messageIds) {
+        await this.processMessage(id);
+      }
+      if (history.data.historyId) {
+        this.lastCheckedHistoryId = history.data.historyId;
+      }
+    } catch (error) {
+      logToFile(`Error checking emails: ${error.message}`);
+    }
+  }
+
+  async processMessage(messageId) {
+    try {
+      const message = await this.gmail.users.messages.get({ userId: 'me', id: messageId });
+      const headers = message.data.payload.headers;
+      const from = headers.find(h => h.name === 'From')?.value || 'Unknown';
+      const subject = headers.find(h => h.name === 'Subject')?.value || 'No Subject';
+      const body = this.extractBody(message.data.payload);
+      await this.sendToDiscord(from, subject, body);
+    } catch (error) {
+      logToFile(`Error processing Gmail message: ${error.message}`);
+    }
+  }
+
+  extractBody(payload) {
+    let body = '';
+    if (payload.body && payload.body.data) {
+      body = Buffer.from(payload.body.data, 'base64').toString('utf-8');
+    } else if (payload.parts) {
+      for (const part of payload.parts) {
+        if (part.mimeType === 'text/plain' && part.body && part.body.data) {
+          body = Buffer.from(part.body.data, 'base64').toString('utf-8');
+          break;
+        }
+      }
+    }
+    if (body.length > 1900) {
+      body = body.substring(0, 1900) + '...';
+    }
+    return body || 'No text content';
+  }
+
+  async sendToDiscord(from, subject, text) {
+    try {
+      const channel = await this.client.channels.fetch(this.channelId);
+      const embed = {
+        color: 0x0099ff,
+        title: '📧 New Email',
+        fields: [
+          { name: 'From', value: from, inline: true },
+          { name: 'Subject', value: subject || 'No Subject', inline: true },
+          { name: 'Content', value: text || 'No content' },
+        ],
+        timestamp: new Date(),
+      };
+      await channel.send({ embeds: [embed] });
+    } catch (error) {
+      logToFile(`Error sending email to Discord: ${error.message}`);
+    }
+  }
+
+  startPolling(intervalMinutes = 5) {
+    this.checkForNewEmails();
+    setInterval(() => this.checkForNewEmails(), intervalMinutes * 60 * 1000);
+    logToFile(`Gmail polling started - checking every ${intervalMinutes} minutes`);
+  }
+}
+
+module.exports = GmailPoller;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const cors = require('cors');
 const app = express();
 const { commands } = require('./commands');
 const { initEmailForwarder } = require('./email_forwarder');
+const GmailPoller = require('./email_poller');
 
 // Simple helper for rate-limited GET requests with retries
 async function axiosGetWithRetry(url, headers, retries = 3, backoff = 1000) {
@@ -122,6 +123,12 @@ const TEAM_ROLE_ID = '1364657163598823474';
 const TODO_CHANNEL_ID = process.env.TODO_CHANNEL_ID;
 // Email forwarding channel ID
 const EMAIL_CHANNEL_ID = process.env.EMAIL_CHANNEL_ID;
+const ENABLE_GMAIL_POLLER = process.env.ENABLE_GMAIL_POLLER === 'true';
+const GMAIL_CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(process.cwd(), 'credentials.json');
+const GMAIL_TOKEN_PATH = process.env.GMAIL_TOKEN_PATH || path.join(process.cwd(), 'token.json');
+const GMAIL_POLL_INTERVAL = parseInt(process.env.GMAIL_POLL_INTERVAL, 10) || 5;
+const GMAIL_CREDENTIALS_JSON = process.env.GMAIL_CREDENTIALS_JSON;
+const GMAIL_TOKEN_JSON = process.env.GMAIL_TOKEN_JSON;
 
 // Store jobs in memory, each with a tag, cron expression, text, and whether to send a notification 5 min before
 let jobs = [
@@ -876,7 +883,7 @@ function findBestPropertyMatch(propertyPage, targetName) {
 }
 
 // When the client is ready, run this code
-client.once('ready', () => {
+client.once('ready', async () => {
   console.log('Bot is ready!');
   logToFile('Bot started successfully');
   
@@ -1024,6 +1031,24 @@ client.once('ready', () => {
   
   // Check next execution times
   checkAllNextExecutionTimes();
+
+  // Start Gmail polling if enabled
+  if (ENABLE_GMAIL_POLLER && EMAIL_CHANNEL_ID) {
+    try {
+      const emailPoller = new GmailPoller(
+        client,
+        EMAIL_CHANNEL_ID,
+        GMAIL_CREDENTIALS_PATH,
+        GMAIL_TOKEN_PATH,
+        GMAIL_CREDENTIALS_JSON,
+        GMAIL_TOKEN_JSON
+      );
+      await emailPoller.initialize();
+      emailPoller.startPolling(GMAIL_POLL_INTERVAL);
+    } catch (error) {
+      logToFile(`Failed to start Gmail polling: ${error.message}`);
+    }
+  }
   
   // Start a health check interval to monitor the schedule system
   startScheduleHealthCheck();

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "moment-timezone": "^0.5.48",
     "node-cron": "^3.0.3",
     "openai": "^4.96.0",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "googleapis": "^118.0.0",
+    "@google-cloud/local-auth": "^2.1.0"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
- add GmailPoller class for polling Gmail and sending messages to Discord
- wire up Gmail polling in `index.js`
- add configuration variables in `config.example.env`
- update README with Gmail poller docs
- include googleapis packages
- allow Gmail credentials to be supplied via environment variables

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*
