### PR TITLE
Fix Runway API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ OPENAI_API_KEY=your_openai_api_key
 ELEVENLABS_API_KEY=your_elevenlabs_api_key
 ELEVENLABS_VOICE_ID=your_elevenlabs_voice_id
 RUNWAY_API_KEY=your_runway_api_key
-RUNWAY_MODEL=stable-video-diffusion
+RUNWAY_MODEL=gen4_turbo
 FRAMEIO_TOKEN=your_frameio_api_token (optional)
 FRAMEIO_ACCOUNT_ID=your_frameio_account_id (optional, auto-detected if omitted)
 
@@ -118,6 +118,7 @@ The bot supports various slash commands:
 - `/frameio [timeframe]` - Fetch recent Frame.io comments to test connectivity
 - `/vo <text>` - Generate an ElevenLabs voiceover and send it
 - `/video <prompt> <image> [duration]` - Generate a video from an image using Runway
+  (requires API version header `X-Runway-Version: 2024-11-06`)
 
 
 ## Creds 2.0


### PR DESCRIPTION
## Summary
- update Runway video generation to use `/image_to_video` endpoint
- include required `X-Runway-Version` header when polling
- update docs with new `RUNWAY_MODEL` default and header note

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*