### PR TITLE
Add env-based Gmail config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ EMAIL_CHANNEL_ID=channel_id_for_forwarding
 ENABLE_GMAIL_POLLER=false
 GMAIL_CREDENTIALS_PATH=credentials.json
 GMAIL_TOKEN_PATH=token.json
+GMAIL_CREDENTIALS_JSON=
+GMAIL_TOKEN_JSON=
 GMAIL_POLL_INTERVAL=5
 ```
 
@@ -95,7 +97,9 @@ the same value.
 2. Set `EMAIL_CHANNEL_ID` in your `.env` with the Discord channel that should receive the messages.
 
 ## Gmail Poller
-Set `ENABLE_GMAIL_POLLER` to `true` to poll Gmail automatically. The bot will use `GMAIL_CREDENTIALS_PATH` and `GMAIL_TOKEN_PATH` for authentication and check every `GMAIL_POLL_INTERVAL` minutes. New emails are posted to `EMAIL_CHANNEL_ID`.
+Set `ENABLE_GMAIL_POLLER` to `true` to poll Gmail automatically. The bot will use `GMAIL_CREDENTIALS_PATH` and `GMAIL_TOKEN_PATH` for file-based authentication and check every `GMAIL_POLL_INTERVAL` minutes. New emails are posted to `EMAIL_CHANNEL_ID`.
+
+If you prefer not to store the credential files on disk, provide the contents via `GMAIL_CREDENTIALS_JSON` and `GMAIL_TOKEN_JSON` environment variables instead.
 
 
 ### Using GitHub Actions + Railway

--- a/config.example.env
+++ b/config.example.env
@@ -39,4 +39,7 @@ GUILD_ID=your_guild_id_here
 ENABLE_GMAIL_POLLER=false
 GMAIL_CREDENTIALS_PATH=credentials.json
 GMAIL_TOKEN_PATH=token.json
+# Alternatively, provide credentials and token directly as JSON strings
+GMAIL_CREDENTIALS_JSON=
+GMAIL_TOKEN_JSON=
 GMAIL_POLL_INTERVAL=5

--- a/index.js
+++ b/index.js
@@ -126,6 +126,8 @@ const EMAIL_CHANNEL_ID = process.env.EMAIL_CHANNEL_ID;
 const ENABLE_GMAIL_POLLER = process.env.ENABLE_GMAIL_POLLER === 'true';
 const GMAIL_CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(process.cwd(), 'credentials.json');
 const GMAIL_TOKEN_PATH = process.env.GMAIL_TOKEN_PATH || path.join(process.cwd(), 'token.json');
+const GMAIL_CREDENTIALS_JSON = process.env.GMAIL_CREDENTIALS_JSON ? JSON.parse(process.env.GMAIL_CREDENTIALS_JSON) : null;
+const GMAIL_TOKEN_JSON = process.env.GMAIL_TOKEN_JSON ? JSON.parse(process.env.GMAIL_TOKEN_JSON) : null;
 const GMAIL_POLL_INTERVAL = parseInt(process.env.GMAIL_POLL_INTERVAL, 10) || 5;
 
 // Store jobs in memory, each with a tag, cron expression, text, and whether to send a notification 5 min before
@@ -1033,7 +1035,14 @@ client.once('ready', async () => {
   // Start Gmail polling if enabled
   if (ENABLE_GMAIL_POLLER && EMAIL_CHANNEL_ID) {
     try {
-      const emailPoller = new GmailPoller(client, EMAIL_CHANNEL_ID, GMAIL_CREDENTIALS_PATH, GMAIL_TOKEN_PATH);
+      const emailPoller = new GmailPoller(
+        client,
+        EMAIL_CHANNEL_ID,
+        GMAIL_CREDENTIALS_PATH,
+        GMAIL_TOKEN_PATH,
+        GMAIL_CREDENTIALS_JSON,
+        GMAIL_TOKEN_JSON
+      );
       await emailPoller.initialize();
       emailPoller.startPolling(GMAIL_POLL_INTERVAL);
     } catch (error) {


### PR DESCRIPTION
## Summary
- support Gmail credentials from environment variables
- document new variables in README and example config

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*